### PR TITLE
Generalize all variable names

### DIFF
--- a/experimental_control/biconditional_20170111.m
+++ b/experimental_control/biconditional_20170111.m
@@ -79,9 +79,9 @@ biconditional.feeder_delay = biconditional.light_duration + ...
 % biconditional.feeder_delay = 0; % used for magazine training
 
 % Initializing timers
-control.steady_on_timer = timer('StartDelay', biconditional.light_delay, ...
+control.light1_on_timer = timer('StartDelay', biconditional.light_delay, ...
     'TimerFcn', @(~, ~) set_nlx('on', light1));
-control.steady_off_timer = timer('StartDelay', biconditional.light_duration, ...
+control.light1_off_timer = timer('StartDelay', biconditional.light_duration, ...
     'TimerFcn', @(~, ~) set_nlx('off', light1));
 
 control.pulse_on_timer = timer('StartDelay', 0, 'Period', light2.on_duration*2, ...
@@ -89,10 +89,10 @@ control.pulse_on_timer = timer('StartDelay', 0, 'Period', light2.on_duration*2, 
 control.pulse_off_timer = timer('StartDelay', light2.on_duration, 'Period', light2.on_duration*2, ...
     'TimerFcn', @(~, ~) NlxSendCommand([light2.command, ' AcqSystem1_0 ', light2.port, ' ' , light2.pin, ' off']), 'ExecutionMode', 'fixedSpacing');
 
-control.flash_on_timer = timer('StartDelay', biconditional.light_delay, ...
+control.light2_on_timer = timer('StartDelay', biconditional.light_delay, ...
     'TimerFcn', @(~, ~) pulse(control.pulse_on_timer, control.pulse_off_timer, light2));
-control.flash_off_timer = timer('StartDelay', biconditional.light_duration, ...
-    'TimerFcn', @(~, ~) stop_timer(control.flash_on_timer, control.pulse_on_timer, control.pulse_off_timer, light2));
+control.light2_off_timer = timer('StartDelay', biconditional.light_duration, ...
+    'TimerFcn', @(~, ~) stop_timer(control.light2_on_timer, control.pulse_on_timer, control.pulse_off_timer, light2));
 
 control.sound1_on_timer = timer('StartDelay', biconditional.light_duration + biconditional.pause_duration, ...
     'TimerFcn', @(~, ~) set_nlx('off', sound1));
@@ -115,8 +115,8 @@ control.trial4_event = '-PostEvent trial4_start 66 6';
 
 %% Check steady left light & sound1
 disp(['Checking the steady light (', num2str(biconditional.light_duration), ' sec)']);
-start(control.steady_off_timer);
-start(control.steady_on_timer);
+start(control.light1_off_timer);
+start(control.light1_on_timer);
 
 disp(['Checking the click (pause ', num2str(biconditional.light_duration + biconditional.pause_duration), ' sec; on for ', num2str(biconditional.sound_duration), ' sec)']);
 start(control.sound1_off_timer);
@@ -126,8 +126,8 @@ start(control.sound1_on_timer);
 %% Check flashing right light & white-noise & feeder (2 pellets)
 
 disp(['Checking the flashing light (', num2str(biconditional.light_duration), ' sec)']);
-start(control.flash_off_timer);
-start(control.flash_on_timer);
+start(control.light2_off_timer);
+start(control.light2_on_timer);
 
 disp(['Checking the white-noise (pause ', num2str(biconditional.light_duration + biconditional.pause_duration), ' sec; on for ', num2str(biconditional.sound_duration), ' sec)']);
 start(control.sound2_off_timer);
@@ -148,16 +148,16 @@ disp('Maze initialized. Empty pellets. Ready to start experiment!');
 
 %% Set up daily trials, itis
 
-n_trials = 32;
+% n_trials = 32;
 
 % % Test
-% trials = [1, 2, 3, 4, 1, 2, 3, 4, 1];
-% itis = [5, 5, 5, 5, 5, 5, 5, 5, 5];
-% n_trials = 4;
+trials = [1, 2, 3, 4, 1, 2, 3, 4, 1];
+itis = [2, 2, 2, 2, 5, 5, 5, 5, 5];
+n_trials = 4;
 
 % Magazine training
-% trials = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
-% itis = [150, 210, 330, 330, 150, 210, 270, 270, 330, 150, 270, 150, 270, 210, 330, 210, 150];
+%trials = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+%itis = [150, 210, 330, 330, 150, 210, 270, 270, 330, 150, 270, 150, 270, 210, 330, 210, 150];
 % n_trials = 16;
 
 % Session 1

--- a/experimental_control/f_biconditional.m
+++ b/experimental_control/f_biconditional.m
@@ -15,39 +15,39 @@ function f_biconditional(trial, control)
 	if control.group == 1
 	    if trial == 1
 	    	% Steady light (10 s), pause (5 s), white-noise (10 s), unrewarded
-	        run_trial(control, control.trial1_event, control.steady_on_timer, ...
-	        control.steady_off_timer, control.noise_on_timer, control.noise_off_timer, [])
+	        run_trial(control, control.trial1_event, control.light1_on_timer, ...
+	        control.light1_off_timer, control.sound2_on_timer, control.sound2_off_timer, [])
 	    elseif trial == 2
 	        % Steady light (10 s), pause (5 s), tone (10 s), rewarded
-	        run_trial(control, control.trial2_event, control.steady_on_timer, ...
-	        control.steady_off_timer, control.tone_on_timer, control.tone_off_timer, control.feeder_timer)
+	        run_trial(control, control.trial2_event, control.light1_on_timer, ...
+	        control.light1_off_timer, control.sound1_on_timer, control.sound1_off_timer, control.feeder_timer)
 	    elseif trial == 3
 	        % Flashing light (10 s), pause (5 s), tone (10 s), unrewarded
-	        run_trial(control, control.trial3_event, control.flash_on_timer, ...
-	        control.flash_off_timer, control.tone_on_timer, control.tone_off_timer, [])
+	        run_trial(control, control.trial3_event, control.light2_on_timer, ...
+	        control.light2_off_timer, control.sound1_on_timer, control.sound1_off_timer, [])
 	    elseif trial == 4
 	        % Flashing light (10 s), pause (5 s), white-noise (10 s), rewarded
-	        run_trial(control, control.trial4_event, control.flash_on_timer, ...
-	        control.flash_off_timer, control.noise_on_timer, control.noise_off_timer, control.feeder_timer)
+	        run_trial(control, control.trial4_event, control.light2_on_timer, ...
+	        control.light2_off_timer, control.sound2_on_timer, control.sound2_off_timer, control.feeder_timer)
 	    end
 
     elseif control.group == 2
     	if trial == 1
 	    	% Flashing light (10 s), pause (5 s), white-noise (10 s), unrewarded
-	        run_trial(control, control.trial1_event, control.flash_on_timer, ...
-	        control.flash_off_timer, control.noise_on_timer, control.noise_off_timer, [])
+	        run_trial(control, control.trial1_event, control.light2_on_timer, ...
+	        control.light2_off_timer, control.sound2_on_timer, control.sound2_off_timer, [])
 	    elseif trial == 2
 	        % Flashing light (10 s), pause (5 s), tone (10 s), rewarded
-	        run_trial(control, control.trial2_event, control.flash_on_timer, ...
-	        control.flash_off_timer, control.tone_on_timer, control.tone_off_timer, control.feeder_timer)
+	        run_trial(control, control.trial2_event, control.light2_on_timer, ...
+	        control.light2_off_timer, control.sound1_on_timer, control.sound1_off_timer, control.feeder_timer)
 	    elseif trial == 3
 	        % Steady light (10 s), pause (5 s), tone (10 s), unrewarded
-	        run_trial(control, control.trial3_event, control.steady_on_timer, ...
-	        control.steady_off_timer, control.tone_on_timer, control.tone_off_timer, [])
+	        run_trial(control, control.trial3_event, control.light1_on_timer, ...
+	        control.light1_off_timer, control.sound1_on_timer, control.sound1_off_timer, [])
 	    elseif trial == 4
 	        % Steady light (10 s), pause (5 s), white-noise (10 s), rewarded
-	        run_trial(control, control.trial4_event, control.steady_on_timer, ...
-	        control.steady_off_timer, control.noise_on_timer, control.noise_off_timer, control.feeder_timer)
+	        run_trial(control, control.trial4_event, control.light1_on_timer, ...
+	        control.light1_off_timer, control.sound2_on_timer, control.sound2_off_timer, control.feeder_timer)
         end
 
     elseif control.group == 3
@@ -94,16 +94,16 @@ end
 function stop_all(control)
     % Stops all timers
  
-    stop(control.steady_off_timer);
-    stop(control.flash_off_timer);
-    stop(control.tone_off_timer);
-    stop(control.noise_off_timer);
+    stop(control.light1_off_timer);
+    stop(control.light2_off_timer);
+    stop(control.sound1_off_timer);
+    stop(control.sound2_off_timer);
     
     stop(control.feeder_timer);
     
-    stop(control.steady_on_timer);
-    stop(control.flash_on_timer);
-    stop(control.tone_on_timer);
-    stop(control.noise_on_timer);
+    stop(control.light1_on_timer);
+    stop(control.light2_on_timer);
+    stop(control.sound1_on_timer);
+    stop(control.sound2_on_timer);
     
 end


### PR DESCRIPTION
**Description:** 
Renaming variables in matlab control script (which controls
the neuralynx biconditional setup). 

**Motivation and context:**
Now that the tone sound has been changed to a click,
I thought it would be a good idea to generalize all the
cue variable names so that it's easy to modify cue presentations
in future experiments using the same (or very similar) control
scripts. For example, if we decide to change the flashing light 
and the steady light, these variables are currently "light1" and 
"light2", and so can be assigned to either steady or flashing.

<!--- **Interactions with other PRs:** -->

**How has this been tested?** 
Currently running these scripts with neuralynx. 
The experiment finished with no errors. No other
formal tests have been written.

<!--- **Where should a reviewer start? -->

**How long should this take to review?**
Quick

**Types of changes:**
Primarily changes to variable names (in all matlab scripts).
Now these names are more generalized (eg. light1, light2).